### PR TITLE
Simplify configuration stage

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,7 @@ include setup*.py
 include MANIFEST.in
 include *.txt
 include Makefile
-include mltsp.yaml.example
-recursive-include mltsp *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.md5 *.npy *.txt
+recursive-include mltsp *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.md5 *.npy *.txt *.yaml
 recursive-include mltsp/data *
 recursive-include dockerfiles Dockerfile *.config *.conf *.py *.sh *.txt *.patch *.md
 recursive-include tools

--- a/doc/install.md
+++ b/doc/install.md
@@ -75,18 +75,9 @@ Then activate it:
 
 ## Configuration
 
-* In the file ``cfg.py`, locate the following variables and set
-  them to reflect your system architecture:
+* Execute ``import mltsp; mltsp.install()``
 
-  ``PROJECT_PATH``
-
-  Optionally, also set
-
-  ``MODELS_FOLDER, UPLOAD_FOLDER, FEATURES_FOLDER, ERR_LOG_PATH``
-
-* Authentication information is currently stored in ``mltsp.yaml``
-  (an example is provided as ``mltsp.yaml.example``).  This
-  configuration file and ``cfg.py`` will eventually become one.
+* Locate ``~/.config/mltsp/mltsp.yaml`` and customize authentication tokens.
 
 
 ## Starting the application

--- a/mltsp/Flask/flask_app.py
+++ b/mltsp/Flask/flask_app.py
@@ -9,6 +9,7 @@ import os
 sys_admin_emails = ['a.crellinquick@gmail.com']
 
 from .. import cfg
+from ..cfg import config
 
 import shutil
 import time
@@ -24,7 +25,6 @@ from werkzeug import secure_filename
 import uuid
 import ntpath
 
-import yaml
 if os.getenv("DEBUG_LOGIN") == "1":
     from ..ext import stormpath_mock as stormpath
 else:
@@ -51,17 +51,6 @@ app.add_url_rule(
     view_func=app.send_static_file)
 
 
-# Load configuration
-config_file = os.path.join(os.path.dirname(__file__), '../../mltsp.yaml')
-try:
-    config = yaml.load(open(config_file))
-except IOError:
-    print("Error!  Could not load 'mltsp.yaml' configuration file.\n"
-          "Please rename 'mltsp.yaml.example' to 'mltsp.yaml' and \n"
-          "modify as necessary.")
-    sys.exit(-1)
-
-
 app.config['SECRET_KEY'] = config['flask']['secret-key']
 app.config['STORMPATH_API_KEY_ID'] = \
     config['authentication']['stormpath_api_key_id']
@@ -78,7 +67,9 @@ if config['authentication']['google_client_id'] is not None:
             'client_secret': config['authentication']['google_client_secret'],
         }
     }
-
+else:
+    print('(!) No Google authentication token in configuration file.')
+    print('(!) Disabling Google logins.')
 
 # Authentication is done using Stormpath
 # http://flask-stormpath.readthedocs.org/

--- a/mltsp/__init__.py
+++ b/mltsp/__init__.py
@@ -1,1 +1,31 @@
+"""Machine Learning Time-Series Platform (MLTSP)
+
+See http://mltsp.io for more information.
+"""
+
 __version__ = '0.3dev'
+
+
+def install():
+    """Install MLTSP config file in ~/.config/mltsp/mltsp.yaml.
+
+    """
+    import os
+    import shutil
+
+    cfg = os.path.expanduser('~/.config/mltsp/mltsp.yaml')
+    cfg_dir = os.path.dirname(cfg)
+
+    if os.path.exists(cfg):
+        print('Existing configuration at {} -- not overwriting.'.format(cfg))
+        return
+
+    if not os.path.exists(cfg_dir):
+        os.makedirs(cfg_dir)
+
+    shutil.copyfile(os.path.join(os.path.dirname(__file__),
+                                 'mltsp.yaml.example'),
+                    cfg)
+
+    print('Installed {}'.format(cfg))
+    print('Please customize this file with authentication tokens, etc.')

--- a/mltsp/cfg.py
+++ b/mltsp/cfg.py
@@ -5,10 +5,37 @@
 from __future__ import print_function
 import os, sys
 
+import yaml
+
+# Load configuration
+config_files = [
+    os.path.expanduser('~/.config/mltsp/mltsp.yaml'),
+    os.path.join(os.path.dirname(__file__), '../mltsp.yaml')
+    ]
+
+config_files = [os.path.abspath(cf) for cf in config_files]
+
+config = {}
+for cf in config_files:
+    try:
+        config = yaml.load(open(cf))
+        break
+    except IOError:
+        pass
+
+if not config:
+    print("Warning!  No 'mltsp.yaml' configuration found in one of:\n\n",
+          '\n '.join(config_files),
+          "\n\nPlease refer to the installation guide for further\n"
+          "instructions.\n\n"
+          "If you don't want to read the manual, do the following:\n"
+          "  import mltsp; mltsp.install()")
+    sys.exit(-1)
+
 # Specify path to project directory:
 PROJECT_PATH = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 MLTSP_PACKAGE_PATH = os.path.abspath(os.path.dirname(__file__))
-DATA_PATH = os.path.join(PROJECT_PATH, "data")
+DATA_PATH = os.path.expanduser('~/.local/mltsp/')
 SAMPLE_DATA_PATH = os.path.join(DATA_PATH, "sample_data")
 
 # Specify path to uploads, models, and feature folders:
@@ -200,3 +227,7 @@ for path in (DATA_PATH, UPLOAD_FOLDER, MODELS_FOLDER, FEATURES_FOLDER,
             os.makedirs(path)
         except Exception as e:
             print(e)
+
+del yaml, os, sys, print_function, config_files
+
+config['mltsp'] = locals()


### PR DESCRIPTION
Users can now get up and running with:

``import mltsp; mltsp.install()``

May have to work around authentication requirements still in another PR.