### PR TITLE
Fix bug causing feature test failures in Python3

### DIFF
--- a/mltsp/TCP/Software/feature_extract/Code/generators_importers/from_xml.py
+++ b/mltsp/TCP/Software/feature_extract/Code/generators_importers/from_xml.py
@@ -31,7 +31,7 @@ class from_xml(gen_or_imp):
             for i in range(len(d['ucds'])):
                 if i == obs_ind:
                     continue
-                if type(d['ucds'][i]) == bytes and d['ucds'][i].find(ucd_obs) != -1:
+                if type(d['ucds'][i]) == str and d['ucds'][i].find(ucd_obs) != -1:
                     for e in ucd_error_values:
                         if d['ucds'][i].find(e) != -1:
                             return i


### PR DESCRIPTION
`type('')==bytes` evaluates to `True` in Python2, and `False` in Python3. This
was causing some variable to never be set, which eventually led to
various silent errors downstream; the ultimate result was the
uncertainty values not being properly loaded from the data, which caused
all features which used those to have the wrong values.