### PR TITLE
Move run_script_in_container into mltsp sub-directory (fixes #80)

### DIFF
--- a/mltsp/Flask/flask_app.py
+++ b/mltsp/Flask/flask_app.py
@@ -109,10 +109,22 @@ ALLOWED_EXTENSIONS = set([
     'XML', 'JSON'])
 
 
+def user_can_access_features_file(filename):
+    authed_projkeys = get_authed_projkeys()
+    featureset_key = filename.split("_")[0]
+    projkey = rdb.table("features").get(featureset_key)\
+                                   .run(g.rdb_conn)['projkey']
+    return projkey in authed_projkeys
+
+
 # Data read from features directory
 @app.route('/features_data/<path:filename>')
+@stormpath.login_required
 def custom_static_features_data(filename):
-    return send_from_directory(cfg.FEATURES_FOLDER, filename)
+    if user_can_access_features_file(filename):
+        return send_from_directory(cfg.FEATURES_FOLDER, filename)
+    else:
+        return None
 
 
 @app.before_request

--- a/mltsp/Flask/flask_app.py
+++ b/mltsp/Flask/flask_app.py
@@ -124,7 +124,7 @@ def custom_static_features_data(filename):
     if user_can_access_features_file(filename):
         return send_from_directory(cfg.FEATURES_FOLDER, filename)
     else:
-        return None
+        abort(403)
 
 
 @app.before_request

--- a/mltsp/Flask/flask_app.py
+++ b/mltsp/Flask/flask_app.py
@@ -1205,10 +1205,8 @@ def featset_associated_files(featset_key):
     for fpath in [
             os.path.join(cfg.FEATURES_FOLDER, "%s_features.csv" % featset_key),
             os.path.join(cfg.FEATURES_FOLDER, "%s_classes.npy" % featset_key),
-            os.path.join(os.path.join(os.path.join(
-                os.path.dirname(__file__), "static"),
-                "data"),
-                "%s_features_with_classes.csv" % featset_key)]:
+            os.path.join(cfg.FEATURES_FOLDER,
+                         "%s_features_with_classes.csv" % featset_key)]:
         if os.path.exists(fpath):
             fpaths.append(fpath)
     entry_dict = rdb.table("features").get(featset_key).run(g.rdb_conn)

--- a/mltsp/Flask/flask_app.py
+++ b/mltsp/Flask/flask_app.py
@@ -20,7 +20,7 @@ import logging
 import simplejson
 from flask import (
     Flask, request, abort, render_template,
-    session, Response, jsonify, g)
+    session, Response, jsonify, g, send_from_directory)
 from werkzeug import secure_filename
 import uuid
 import ntpath
@@ -107,6 +107,12 @@ ALLOWED_EXTENSIONS = set([
     'txt', 'dat', 'csv', 'fits', 'jpeg', 'gif', 'bmp', 'doc', 'odt', 'xml',
     'json', 'TXT', 'DAT', 'CSV', 'FITS', 'JPEG', 'GIF', 'BMP', 'DOC', 'ODT',
     'XML', 'JSON'])
+
+
+# Data read from features directory
+@app.route('/features_data/<path:filename>')
+def custom_static_features_data(filename):
+    return send_from_directory(cfg.FEATURES_FOLDER, filename)
 
 
 @app.before_request

--- a/mltsp/Flask/static/js/scripts.js
+++ b/mltsp/Flask/static/js/scripts.js
@@ -719,7 +719,7 @@ function plotFeaturesFormSubmit(){
     project_name = $( "#plot_feats_project_name_select" ).val();
     featureset_name = $( "#plot_features_featset_name_select" ).val();
     $.get("/get_featureset_id_by_projname_and_featsetname/"+project_name+"/"+featureset_name,function(data){
-        drawScatterplotMatrix("/static/data/" + data["featureset_id"] + "_features_with_classes.csv");
+        drawScatterplotMatrix("/features_data/" + data["featureset_id"] + "_features_with_classes.csv");
     });
     $('#tabs').tabs( "option", "active",  false);
 }

--- a/mltsp/Flask/templates/index.html
+++ b/mltsp/Flask/templates/index.html
@@ -663,7 +663,7 @@
                                         $("#model_build_results").hide();
                                         $("#class_pred_results").hide();
                                         
-                                        drawScatterplotMatrix("/static/data/{{ PROJECT_NAME }}_features_with_classes.csv");
+                                        drawScatterplotMatrix("/features_data/{{ PROJECT_NAME }}_features_with_classes.csv");
                                         
                                 });
                         
@@ -694,7 +694,7 @@
                                                                         
                                                                 });
                                                                 $('#tabs').tabs( "option", "active", false);
-                                                                drawScatterplotMatrix("/static/data/{{ new_featset_key }}_features_with_classes.csv");
+                                                                drawScatterplotMatrix("/features_data/{{ new_featset_key }}_features_with_classes.csv");
                                                                 clearInterval(checkStatus);
                                                         }
                                                 }

--- a/mltsp/custom_feature_tools.py
+++ b/mltsp/custom_feature_tools.py
@@ -342,7 +342,7 @@ def extract_feats_in_docker_container(container_name, path_to_tmp_dir):
         # Create container
         cont_id = client.create_container(
             image="mltsp/base",
-            command="python {}/run_script_in_container.py --{} --tmp_dir={}".format(
+            command="python {}/mltsp/run_script_in_container.py --{} --tmp_dir={}".format(
                 proj_mount_path, "extract_custom_feats", tmp_data_dir),
             tty=True,
             volumes="{}:{}".format("", proj_mount_path))["Id"]

--- a/mltsp/featurize.py
+++ b/mltsp/featurize.py
@@ -21,7 +21,7 @@ from .celery_tasks import featurize_ts_data as featurize_celery_task
 # TODO use this everywhere?
 def shorten_fname(file_path):
     return os.path.splitext(os.path.basename(file_path))[0]
-    
+
 def parse_prefeaturized_csv_data(features_file_path):
     """Parse CSV file containing features.
 
@@ -290,9 +290,6 @@ def write_features_to_disk(objects, featureset_id, features_to_use,
                 cv_objs.append(obj)
                 num_held_back[str(obj['class'])] += 1
             numobjs += 1
-    if not in_docker_container:
-        shutil.copy2(
-            f2.name, os.path.join(cfg.MLTSP_PACKAGE_PATH, "Flask/static/data"))
     np.save(os.path.join(
         ("/tmp" if in_docker_container else cfg.FEATURES_FOLDER),
         "%s_classes.npy" % featureset_id), classes)
@@ -355,8 +352,6 @@ def featurize(
                            in_docker_container)
     # Clean up
     if not in_docker_container:
-        os.remove(os.path.join(
-            cfg.FEATURES_FOLDER, "%s_features_with_classes.csv" % featureset_id))
         os.remove(headerfile_path)
         if zipfile_path is not None:
             os.remove(zipfile_path)

--- a/mltsp/run_script_in_container.py
+++ b/mltsp/run_script_in_container.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # run_script_in_container.py
+# Will be run inside Docker container
 
 if __name__ == "__main__":
     # Run Cython setup script:
@@ -10,26 +11,16 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description='MLTSP Docker scripts')
     parser.add_argument('--extract_custom_feats', action='store_true')
-    parser.add_argument('--featurize', action='store_true')
-    parser.add_argument('--build_model', action='store_true')
-    parser.add_argument('--predict', action='store_true')
     parser.add_argument('--tmp_dir', dest='tmp_dir', action='store', type=str)
     args = parser.parse_args()
 
     import sys
+    import os
     sys.path.append(args.tmp_dir)
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
     if args.extract_custom_feats:
         from mltsp.docker_scripts import docker_extract_custom_feats
         docker_extract_custom_feats.extract_custom_feats(args.tmp_dir)
-    elif args.featurize:
-        from mltsp.docker_scripts import docker_featurize
-        docker_featurize.do_featurization(args.tmp_dir)
-    elif args.build_model:
-        from mltsp.docker_scripts import docker_build_model
-        docker_build_model.build_model(args.tmp_dir)
-    elif args.predict:
-        from mltsp.docker_scripts import docker_predict
-        docker_predict.predict(args.tmp_dir)
     else:
         raise Exception("No valid script parameter passed to "
-                        "run_script_in_container.py call.")
+                        "run_script_in_container")

--- a/mltsp/run_script_in_container.py
+++ b/mltsp/run_script_in_container.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
     import sys
     import os
     sys.path.append(args.tmp_dir)
+    # Append mltsp package directory to path so it can be imported below
     sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
     if args.extract_custom_feats:
         from mltsp.docker_scripts import docker_extract_custom_feats

--- a/mltsp/run_script_in_container.py
+++ b/mltsp/run_script_in_container.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     import sys
     import os
     sys.path.append(args.tmp_dir)
-    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
     if args.extract_custom_feats:
         from mltsp.docker_scripts import docker_extract_custom_feats
         docker_extract_custom_feats.extract_custom_feats(args.tmp_dir)

--- a/mltsp/tests/test_featurize.py
+++ b/mltsp/tests/test_featurize.py
@@ -139,8 +139,6 @@ def test_write_features_to_disk():
                     "test_featset01_features_with_classes.csv"))
     os.remove(pjoin(cfg.FEATURES_FOLDER,
                     "test_featset01_classes.npy"))
-    os.remove(pjoin(cfg.MLTSP_PACKAGE_PATH, "Flask/static/data",
-                    "test_featset01_features_with_classes.csv"))
     npt.assert_equal(feat_cont, "f1,f2\n21.0,0.15\n23.4,2.31\n")
     npt.assert_equal(feat_class_cont,
                      "class,f1,f2\nc1,21.0,0.15\nc2,23.4,2.31\n")
@@ -174,8 +172,7 @@ def test_main_featurize_function():
     cols = df.columns
     values = df.values
     os.remove(pjoin(cfg.FEATURES_FOLDER, "test_features.csv"))
-    os.remove(pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                          "Flask/static/data"),
+    os.remove(pjoin(cfg.FEATURES_FOLDER,
                     "test_features_with_classes.csv"))
     assert("std_err" in cols)
     assert("f" in cols)

--- a/mltsp/tests/test_flask_app.py
+++ b/mltsp/tests/test_flask_app.py
@@ -1405,8 +1405,7 @@ class FlaskAppTestCase(unittest.TestCase):
                                         "TEST01_features.csv")))
             assert(os.path.exists(pjoin(cfg.FEATURES_FOLDER,
                                         "TEST01_classes.npy")))
-            assert(os.path.exists(pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                                              "Flask/static/data"),
+            assert(os.path.exists(pjoin(cfg.FEATURES_FOLDER,
                                         "TEST01_features_with_classes.csv")))
             os.remove(pjoin(cfg.FEATURES_FOLDER, "TEST01_classes.npy"))
             df = pd.io.parsers.read_csv(pjoin(cfg.FEATURES_FOLDER,
@@ -1415,8 +1414,7 @@ class FlaskAppTestCase(unittest.TestCase):
             values = df.values
             assert "results_msg" in entry
             os.remove(pjoin(cfg.FEATURES_FOLDER, "TEST01_features.csv"))
-            os.remove(pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                                  "Flask/static/data"),
+            os.remove(pjoin(cfg.FEATURES_FOLDER,
                             "TEST01_features_with_classes.csv"))
             assert("std_err" in cols)
             featurize_teardown()
@@ -1993,8 +1991,7 @@ class FlaskAppTestCase(unittest.TestCase):
                                    "%s_classes.npy" % new_key)))
             assert(all(class_name in ["class1", "class2", "class3"] for
                        class_name in classes))
-            assert(os.path.exists(pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                                              "Flask/static/data"),
+            assert(os.path.exists(pjoin(cfg.FEATURES_FOLDER,
                                         "%s_features_with_classes.csv" %
                                         new_key)))
             df = pd.io.parsers.read_csv(pjoin(cfg.FEATURES_FOLDER,
@@ -2007,8 +2004,7 @@ class FlaskAppTestCase(unittest.TestCase):
             for fpath in [
                     pjoin(cfg.FEATURES_FOLDER, "%s_features.csv" % new_key),
                     pjoin(cfg.FEATURES_FOLDER, "%s_classes.npy" % new_key),
-                    pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                                "Flask/static/data"),
+                    pjoin(cfg.FEATURES_FOLDER,
                           "%s_features_with_classes.csv" % new_key)]:
                 if os.path.exists(fpath):
                     fpaths.append(fpath)
@@ -2079,8 +2075,7 @@ class FlaskAppTestCase(unittest.TestCase):
                                       'Classical_Cepheid', 'W_Ursae_Maj',
                                       'Delta_Scuti']
                        for class_name in classes))
-            assert(os.path.exists(pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                                              "Flask/static/data"),
+            assert(os.path.exists(pjoin(cfg.FEATURES_FOLDER,
                                         "%s_features_with_classes.csv" %
                                         new_key)))
             df = pd.io.parsers.read_csv(pjoin(cfg.FEATURES_FOLDER,
@@ -2092,8 +2087,7 @@ class FlaskAppTestCase(unittest.TestCase):
             for fpath in [
                     pjoin(cfg.FEATURES_FOLDER, "%s_features.csv" % new_key),
                     pjoin(cfg.FEATURES_FOLDER, "%s_classes.npy" % new_key),
-                    pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                                "Flask/static/data"),
+                    pjoin(cfg.FEATURES_FOLDER,
                           "%s_features_with_classes.csv" % new_key)]:
                 if os.path.exists(fpath):
                     fpaths.append(fpath)
@@ -2160,8 +2154,7 @@ class FlaskAppTestCase(unittest.TestCase):
                                       'Classical_Cepheid', 'W_Ursae_Maj',
                                       'Delta_Scuti']
                        for class_name in classes))
-            assert(os.path.exists(pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                                              "Flask/static/data"),
+            assert(os.path.exists(pjoin(cfg.FEATURES_FOLDER,
                                         "%s_features_with_classes.csv" %
                                         new_key)))
             df = pd.io.parsers.read_csv(pjoin(cfg.FEATURES_FOLDER,
@@ -2173,8 +2166,7 @@ class FlaskAppTestCase(unittest.TestCase):
             for fpath in [
                     pjoin(cfg.FEATURES_FOLDER, "%s_features.csv" % new_key),
                     pjoin(cfg.FEATURES_FOLDER, "%s_classes.npy" % new_key),
-                    pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                                "Flask/static/data"),
+                    pjoin(cfg.FEATURES_FOLDER,
                           "%s_features_with_classes.csv" % new_key)]:
                 if os.path.exists(fpath):
                     fpaths.append(fpath)
@@ -2232,8 +2224,7 @@ class FlaskAppTestCase(unittest.TestCase):
                                       'Classical_Cepheid', 'W_Ursae_Maj',
                                       'Delta_Scuti']
                        for class_name in classes))
-            assert(os.path.exists(pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                                              "Flask/static/data"),
+            assert(os.path.exists(pjoin(cfg.FEATURES_FOLDER,
                                         "%s_features_with_classes.csv" %
                                         new_key)))
             df = pd.io.parsers.read_csv(pjoin(cfg.FEATURES_FOLDER,
@@ -2246,8 +2237,7 @@ class FlaskAppTestCase(unittest.TestCase):
             for fpath in [
                     pjoin(cfg.FEATURES_FOLDER, "%s_features.csv" % new_key),
                     pjoin(cfg.FEATURES_FOLDER, "%s_classes.npy" % new_key),
-                    pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                                "Flask/static/data"),
+                    pjoin(cfg.FEATURES_FOLDER,
                           "%s_features_with_classes.csv" % new_key)]:
                 if os.path.exists(fpath):
                     fpaths.append(fpath)
@@ -2307,8 +2297,7 @@ class FlaskAppTestCase(unittest.TestCase):
                                    "%s_classes.npy" % new_key)))
             assert(all(class_name in ["class1", "class2", "class3"] for
                        class_name in classes))
-            assert(os.path.exists(pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                                              "Flask/static/data"),
+            assert(os.path.exists(pjoin(cfg.FEATURES_FOLDER,
                                         "%s_features_with_classes.csv" %
                                         new_key)))
             df = pd.io.parsers.read_csv(pjoin(cfg.FEATURES_FOLDER,
@@ -2321,8 +2310,7 @@ class FlaskAppTestCase(unittest.TestCase):
             for fpath in [
                     pjoin(cfg.FEATURES_FOLDER, "%s_features.csv" % new_key),
                     pjoin(cfg.FEATURES_FOLDER, "%s_classes.npy" % new_key),
-                    pjoin(pjoin(cfg.MLTSP_PACKAGE_PATH,
-                                "Flask/static/data"),
+                    pjoin(cfg.FEATURES_FOLDER,
                           "%s_features_with_classes.csv" % new_key)]:
                 if os.path.exists(fpath):
                     fpaths.append(fpath)


### PR DESCRIPTION
Have to do a `sys.path.append` for the import to work now, which is why the script was originally placed where it was, though it's only run inside a Docker container so I think it's fine to do so.