### PR TITLE
Featurization API tweaks

### DIFF
--- a/mltsp/build_model.py
+++ b/mltsp/build_model.py
@@ -26,7 +26,7 @@ def rectangularize_featureset(featureset):
         if len(featureset.channel) == 1:
             feature_df.columns = [pair[0] for pair in feature_df.columns]
         else:
-            feature_df.columns = ['_'.join(pair)
+            feature_df.columns = ['_'.join([str(el) for el in pair])
                                   for pair in feature_df.columns]
     return feature_df
 

--- a/mltsp/cfg.py
+++ b/mltsp/cfg.py
@@ -227,8 +227,9 @@ features_to_plot = [
 # Specify number of time series to featurize as part of a "test run"
 TEST_N = 5
 
-# Specify default measurement error value (for measurements without errors)
-ERROR_VALUE = 1e-4
+# Specify default values for missing times/errors
+DEFAULT_MAX_TIME = 1.0
+DEFAULT_ERROR_VALUE = 1e-4
 
 
 if not os.path.exists(PROJECT_PATH):

--- a/mltsp/featurize.py
+++ b/mltsp/featurize.py
@@ -125,8 +125,8 @@ def featurize_data_file(data_path, header_path=None, features_to_use=[],
 
 
 def featurize_time_series(times, values, errors=None, features_to_use=[],
-                          targets=None, meta_features=None,
-                          custom_script_path=None, labels=None):
+                          targets=None, meta_features=None, labels=None,
+                          custom_script_path=None, custom_functions=None):
     """Versatile feature generation function for one or more time series.
 
     For a single time series, inputs may have the form:
@@ -172,12 +172,20 @@ def featurize_time_series(times, values, errors=None, features_to_use=[],
         dict/Series (for a single time series) or DataFrame (for multiple time
         series) of metafeature information; features are added to the output
         featureset, and their values are consumable by custom feature scripts.
-    custom_script_path : str, optional
-        Path to Python script containing function definitions for the
-        generation of any custom features. Defaults to None.
     labels : str or list of str, optional
         Label or list of labels for each time series, if applicable; will be
         stored in the `name` coordinate of the resulting `xray.Dataset`.
+    custom_script_path : str, optional
+        Path to Python script containing function definitions for the
+        generation of any custom features. Defaults to None.
+    custom_functions : dict, optional
+        Dictionary of custom feature functions to be evaluated for the given time
+        series, or a dictionary representing a dask graph of function evaluations.
+        Dictionaries of functions should have keys `feature_name` and values
+        functions that take arguments (t, m, e); in the case of a
+        dask graph, these arrays should be referenced as 't', 'm', 'e',
+        respectively, and any values with keys present in `features_to_use`
+        will be computed.
 
     Returns
     -------
@@ -216,7 +224,8 @@ def featurize_time_series(times, values, errors=None, features_to_use=[],
         meta_feature_dict = meta_features.loc[label].to_dict()
         features = ft.featurize_single_ts(t, m, e, features_to_use,
                                           meta_features=meta_feature_dict,
-                                          custom_script_path=custom_script_path)
+                                          custom_script_path=custom_script_path,
+                                          custom_functions=custom_functions)
         feature_dicts.append(features)
     return ft.assemble_featureset(feature_dicts, targets, meta_features,
                                   labels)

--- a/mltsp/predict.py
+++ b/mltsp/predict.py
@@ -14,8 +14,8 @@ from . import util
 
 def model_predictions(featureset, model):
     """Construct a DataFrame of model predictions for given featureset."""
-    # Do probabilistic model prediction when possible
     feature_df = build_model.rectangularize_featureset(featureset)
+    # Do probabilistic model prediction when possible
     try:
         preds = model.predict_proba(feature_df)
     except AttributeError:

--- a/mltsp/science_features/periodic_model.py
+++ b/mltsp/science_features/periodic_model.py
@@ -26,10 +26,11 @@ def periodic_model(lomb_model):
     def model_neg(t):
         return -1. * model_f(t)
 
-    min_1_a = optimize.fmin(model_neg, 0.05)[0] # start finding 1st minima, at 5% of phase (fudge/magic number) > 0.018
-    max_2_a = optimize.fmin(model_f, min_1_a + 0.01)[0]
-    min_3_a = optimize.fmin(model_neg, max_2_a + 0.01)[0]
-    max_4_a = optimize.fmin(model_f, min_3_a + 0.01)[0]
+    # Start finding 1st minima, at 5% of phase (fudge/magic number) > 0.018
+    min_1_a = optimize.fmin(model_neg, 0.05, disp=False)[0]
+    max_2_a = optimize.fmin(model_f, min_1_a + 0.01, disp=False)[0]
+    min_3_a = optimize.fmin(model_neg, max_2_a + 0.01, disp=False)[0]
+    max_4_a = optimize.fmin(model_f, min_3_a + 0.01, disp=False)[0]
 
 # TODO !!! is this wrong? seems like it should be a minus
     out_dict['phi1_phi2'] = (min_3_a - max_2_a) / (max_4_a / min_3_a)

--- a/mltsp/tests/test_featurize.py
+++ b/mltsp/tests/test_featurize.py
@@ -69,12 +69,12 @@ def sample_featureset():
 
 def sample_time_series(size=51, channels=1):
     times = np.sort(np.random.random(size))
-    values = np.array([np.random.normal(size=size) for i in range(channels)]).T
+    values = np.array([np.random.normal(size=size) for i in range(channels)])
     errors = np.array([np.random.exponential(size=size)
-                       for i in range(channels)]).T
+                       for i in range(channels)])
     if channels == 1:
-        values = values[:, 0]
-        errors = errors[:, 0]
+        values = values[0]
+        errors = errors[0]
     return times, values, errors
 
 
@@ -165,7 +165,7 @@ def test_featurize_time_series_single():
 
 
 def test_featurize_time_series_single_multichannel():
-    """Test featurize wrapper function for single time series"""
+    """Test featurize wrapper function for single multichannel time series"""
     n_channels = 3
     t, m, e = sample_time_series(channels=n_channels)
     features_to_use = ['amplitude', 'std_err']
@@ -198,7 +198,7 @@ def test_featurize_time_series_multiple():
 
 
 def test_featurize_time_series_multiple_multichannel():
-    """Test featurize wrapper function for multiple time series"""
+    """Test featurize wrapper function for multiple multichannel time series"""
     n_series = 5
     n_channels = 3
     list_of_series = [sample_time_series(channels=n_channels)
@@ -218,24 +218,28 @@ def test_featurize_time_series_multiple_multichannel():
     npt.assert_array_equal(featureset.target.values, targets)
 
 
-def test_featurize_time_series_multiple_tuples():
-    """Test featurize wrapper function for tuples of time series."""
-    n_series = 5
-    list_of_series = [sample_time_series() for i in range(n_series)]
-    times, values, errors = [tuple(x) for x in zip(*list_of_series)]
+def test_featurize_time_series_uneven_multichannel():
+    """Test featurize wrapper function for uneven-length multichannel data"""
+    n_channels = 3
+    t, m, e = sample_time_series(channels=n_channels)
+    t = [[t, t[0:-5], t[0:-10]]]
+    m = [[m[0], m[1][0:-5], m[2][0:-10]]]
+    e = [[e[0], e[1][0:-5], e[2][0:-10]]]
     features_to_use = ['amplitude', 'std_err']
-    targets = np.array(['class1'] * n_series)
-    meta_features = [{'meta1': 0.5}] * n_series
-    featureset = featurize.featurize_time_series(times, values, errors,
-                                                 features_to_use, targets,
-                                                 meta_features)
+    target = 'class1'
+    meta_features = {'meta1': 0.5}
+    featureset = featurize.featurize_time_series(t, m, e, features_to_use,
+                                                 target, meta_features)
     npt.assert_array_equal(sorted(featureset.data_vars),
                            ['amplitude', 'meta1', 'std_err'])
-    npt.assert_array_equal(featureset.target.values, ['class1'] * n_series)
+    npt.assert_array_equal(featureset.channel, np.arange(n_channels))
+    npt.assert_array_equal(list(featureset.amplitude.coords),
+                           ['name', 'channel', 'target'])
+    npt.assert_array_equal(featureset.target.values, ['class1'])
 
 
 def test_featurize_time_series_custom_functions():
-    """Test featurize wrapper function time series w/ custom functions"""
+    """Test featurize wrapper function for time series w/ custom functions"""
     n_channels = 3
     t, m, e = sample_time_series(channels=n_channels)
     features_to_use = ['amplitude', 'std_err', 'test_f']
@@ -254,7 +258,7 @@ def test_featurize_time_series_custom_functions():
 
 
 def test_featurize_time_series_custom_dask_graph():
-    """Test featurize wrapper function time series w/ custom dask graph"""
+    """Test featurize wrapper function for time series w/ custom dask graph"""
     n_channels = 3
     t, m, e = sample_time_series(channels=n_channels)
     features_to_use = ['amplitude', 'std_err', 'test_f']
@@ -270,3 +274,47 @@ def test_featurize_time_series_custom_dask_graph():
     npt.assert_array_equal(list(featureset.amplitude.coords),
                            ['name', 'channel', 'target'])
     npt.assert_array_equal(featureset.target.values, ['class1'])
+
+
+def test_featurize_time_series_default_times():
+    """Test featurize wrapper function for time series w/ missing times"""
+    n_channels = 3
+    _, m, e = sample_time_series(channels=n_channels)
+    features_to_use = ['amplitude', 'std_err']
+    target = 'class1'
+    meta_features = {}
+    featureset = featurize.featurize_time_series(None, m, e, features_to_use,
+                                                 target, meta_features)
+    npt.assert_array_equal(featureset.channel, np.arange(n_channels))
+    m = [[m[0], m[1][0:-5], m[2][0:-10]]]
+    e = [[e[0], e[1][0:-5], e[2][0:-10]]]
+    featureset = featurize.featurize_time_series(None, m, e, features_to_use,
+                                                 target, meta_features)
+    npt.assert_array_equal(featureset.channel, np.arange(n_channels))
+    m = m[0][0]
+    e = e[0][0]
+    featureset = featurize.featurize_time_series(None, m, e, features_to_use,
+                                                 target, meta_features)
+    npt.assert_array_equal(featureset.channel, [0])
+
+
+def test_featurize_time_series_default_errors():
+    """Test featurize wrapper function for time series w/ missing errors"""
+    n_channels = 3
+    t, m, _ = sample_time_series(channels=n_channels)
+    features_to_use = ['amplitude', 'std_err']
+    target = 'class1'
+    meta_features = {}
+    featureset = featurize.featurize_time_series(t, m, None, features_to_use,
+                                                 target, meta_features)
+    npt.assert_array_equal(featureset.channel, np.arange(n_channels))
+    t = [[t, t[0:-5], t[0:-10]]]
+    m = [[m[0], m[1][0:-5], m[2][0:-10]]]
+    featureset = featurize.featurize_time_series(t, m, None, features_to_use,
+                                                 target, meta_features)
+    npt.assert_array_equal(featureset.channel, np.arange(n_channels))
+    t = t[0][0]
+    m = m[0][0]
+    featureset = featurize.featurize_time_series(t, m, None, features_to_use,
+                                                 target, meta_features)
+    npt.assert_array_equal(featureset.channel, [0])


### PR DESCRIPTION
- Allow unequal-length multichannel data (passed in as lists of lists of 1d arrays), e.g. in the case of wavelet-transformed data
- Add support for directly passing custom features as a dict `{'some_feature': f}` where `f(t,m,e)` is a featurization function, or as a dask graph `{'some_feature': (f, 't', 'm', 'e')}`.
- Use default values for times/errors when omitted from `featurize_time_series`