### PR TITLE
Fix rectangularizing featureset w/ unsorted labels

### DIFF
--- a/mltsp/build_model.py
+++ b/mltsp/build_model.py
@@ -28,7 +28,7 @@ def rectangularize_featureset(featureset):
         else:
             feature_df.columns = ['_'.join([str(el) for el in pair])
                                   for pair in feature_df.columns]
-    return feature_df
+    return feature_df.loc[featureset.name]  # preserve original row ordering
 
 
 def build_model_from_featureset(featureset, model=None, model_type=None,

--- a/mltsp/featurize.py
+++ b/mltsp/featurize.py
@@ -226,9 +226,9 @@ def featurize_time_series(times, values, errors=None, features_to_use=[],
 
     if labels is None:
         if isinstance(times, (list, tuple)):
-            labels = np.arange(len(times)).astype('str')
+            labels = np.arange(len(times))
         else:
-            labels = np.array(['0'])
+            labels = np.array([0])
 
     if all([isinstance(x, np.ndarray) for x in (times, values, errors)]):
         times, values, errors = ([times], [values], [errors])

--- a/mltsp/predict.py
+++ b/mltsp/predict.py
@@ -20,7 +20,7 @@ def model_predictions(featureset, model):
         preds = model.predict_proba(feature_df)
     except AttributeError:
         preds = model.predict(feature_df)
-    preds_df = pd.DataFrame(preds, index=featureset.name)
+    preds_df = pd.DataFrame(preds, index=feature_df.index)
     if preds_df.shape[1] == 1:
         preds_df.columns = ['prediction']
     else:


### PR DESCRIPTION
Small (bug?)fix: the main work of `rectangularize_featureset` is done by the Pandas `unstack` function, which automatically sorts the dataframe (by row); this leads to unexpected behavior when e.g. checking model predictions against a list of known targets. This change explicitly undoes any sorting and preserves the original ordering of `featureset.name`, which I think is how one would expect it to work.