### PR TITLE
Python3 fixes: str encodings, iterator usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,7 @@
 SHELL = /bin/bash
 PY_VER = $(shell python -c 'import sys; print(sys.version_info.major)')
 
-py2:
-	@if [[ $(PY_VER) != 2 ]]; then \
-		echo -e "\n** Error: currently, MLTSP relies on Python 2.x **\n"; \
-		exit 1; \
-	fi
-
-celery: py2
+celery:
 	@if [[ -z `ps ax | grep -v grep | grep -v make | grep celery_tasks` ]]; then \
 		PYTHONPATH="./mltsp" celery worker -A celery_tasks -l info >>/tmp/celery.log 2>&1 & \
 	else \
@@ -18,38 +12,38 @@ celery: py2
 
 .DEFAULT_GOAL := all
 
-all: py2
+all:
 	python setup.py build_ext -i
 
 clean:
 	find . -name "*.so" | xargs rm
 
-webapp: db py2 celery
+webapp: db celery
 	PYTHONPATH=. tools/launch_waitress.py
 
-init: py2 db celery
+init: db celery
 	mltsp --db-init --force
 
 db:
 	@if [[ -n `rethinkdb --daemon 2>&1 | grep "already in use"` ]]; then echo "[RethinkDB] is (probably) already running"; fi
 
-external/casperjs: py2
+external/casperjs:
 	@tools/casper_install.sh
 
-test_backend: db py2 celery
+test_backend: db celery
 	nosetests -v mltsp
 
 test_backend_no_docker: export MLTSP_NO_DOCKER=1
-test_backend_no_docker: db py2 celery
+test_backend_no_docker: db celery
 	nosetests -v mltsp
 
 test_frontend: export MLTSP_DEBUG_LOGIN=1
-test_frontend: external/casperjs py2 db celery
+test_frontend: external/casperjs db celery
 	@PYTHONPATH="." tools/casper_tests.py
 
 test_frontend_no_docker: export MLTSP_NO_DOCKER=1
 test_frontend_no_docker: export MLTSP_DEBUG_LOGIN=1
-test_frontend_no_docker: external/casperjs py2 db celery
+test_frontend_no_docker: external/casperjs db celery
 	@PYTHONPATH="." tools/casper_tests.py
 
 test_entrypoint:
@@ -59,5 +53,5 @@ test: test_entrypoint test_backend test_frontend
 
 test_no_docker: test_backend_no_docker test_frontend_no_docker
 
-install: py2
+install:
 	pip install -r requirements.txt

--- a/mltsp/featurize_tools.py
+++ b/mltsp/featurize_tools.py
@@ -93,7 +93,7 @@ def featurize_single_ts(t, m, e, features_to_use, meta_features={},
                 dask_graph = {key: value
                               for key, value in custom_functions.items()
                               if key in features_to_use}
-                dask_keys = dask_graph.keys()
+                dask_keys = list(dask_graph.keys())
                 dask_graph['t'] = t[i]
                 dask_graph['m'] = m[i]
                 dask_graph['e'] = e[i]

--- a/mltsp/obs_feature_tools.py
+++ b/mltsp/obs_feature_tools.py
@@ -58,7 +58,7 @@ def find_sorted_peaks(x):
                 if j == nbins-1 and x[i] == x[j]: # Reached the end
                     peak_inds.append(i)
     sorted_peak_inds = sorted(peak_inds, key=lambda i: x[i], reverse=True)
-    return zip(sorted_peak_inds, x[sorted_peak_inds])
+    return list(zip(sorted_peak_inds, x[sorted_peak_inds]))
 
 
 def peak_ratio(peaks, i, j):

--- a/mltsp/tests/test_featurize.py
+++ b/mltsp/tests/test_featurize.py
@@ -83,11 +83,11 @@ def test_write_features_to_disk():
     featurize.write_features_to_disk(sample_featureset(), "test")
     featureset = xray.open_dataset(pjoin(cfg.FEATURES_FOLDER,
                                          "test_featureset.nc"))
-    npt.assert_equal(list(featureset.data_vars), ['f1', 'f2'])
-    npt.assert_equal(list(featureset.coords), ['target', 'name'])
+    npt.assert_equal(sorted(featureset.data_vars), ['f1', 'f2'])
+    npt.assert_equal(sorted(featureset.coords), ['name', 'target'])
     npt.assert_equal(featureset['f1'].values, [21.0, 23.4])
     npt.assert_equal(featureset['f2'].values, [0.15, 2.31])
-    npt.assert_equal(featureset['target'].values, ['c1', 'c2'])
+    npt.assert_equal(featureset['target'].values, [b'c1', b'c2'])
 
 
 @with_setup(copy_classification_test_data, remove_test_data)
@@ -176,8 +176,8 @@ def test_featurize_time_series_single_multichannel():
     npt.assert_array_equal(sorted(featureset.data_vars),
                            ['amplitude', 'meta1', 'std_err'])
     npt.assert_array_equal(featureset.channel, np.arange(n_channels))
-    npt.assert_array_equal(list(featureset.amplitude.coords),
-                           ['name', 'channel', 'target'])
+    npt.assert_array_equal(sorted(featureset.amplitude.coords),
+                           ['channel', 'name', 'target'])
     npt.assert_array_equal(featureset.target.values, ['class1'])
 
 
@@ -213,8 +213,8 @@ def test_featurize_time_series_multiple_multichannel():
     npt.assert_array_equal(sorted(featureset.data_vars),
                            ['amplitude', 'meta1', 'std_err'])
     npt.assert_array_equal(featureset.channel, np.arange(n_channels))
-    npt.assert_array_equal(list(featureset.amplitude.coords),
-                           ['name', 'channel', 'target'])
+    npt.assert_array_equal(sorted(featureset.amplitude.coords),
+                           ['channel', 'name', 'target'])
     npt.assert_array_equal(featureset.target.values, targets)
 
 
@@ -233,8 +233,8 @@ def test_featurize_time_series_uneven_multichannel():
     npt.assert_array_equal(sorted(featureset.data_vars),
                            ['amplitude', 'meta1', 'std_err'])
     npt.assert_array_equal(featureset.channel, np.arange(n_channels))
-    npt.assert_array_equal(list(featureset.amplitude.coords),
-                           ['name', 'channel', 'target'])
+    npt.assert_array_equal(sorted(featureset.amplitude.coords),
+                           ['channel', 'name', 'target'])
     npt.assert_array_equal(featureset.target.values, ['class1'])
 
 
@@ -252,8 +252,8 @@ def test_featurize_time_series_custom_functions():
     npt.assert_array_equal(sorted(featureset.data_vars),
                            ['amplitude', 'meta1', 'std_err', 'test_f'])
     npt.assert_array_equal(featureset.channel, np.arange(n_channels))
-    npt.assert_array_equal(list(featureset.amplitude.coords),
-                           ['name', 'channel', 'target'])
+    npt.assert_array_equal(sorted(featureset.amplitude.coords),
+                           ['channel', 'name', 'target'])
     npt.assert_array_equal(featureset.target.values, ['class1'])
 
 
@@ -271,8 +271,8 @@ def test_featurize_time_series_custom_dask_graph():
     npt.assert_array_equal(sorted(featureset.data_vars),
                            ['amplitude', 'meta1', 'std_err', 'test_f'])
     npt.assert_array_equal(featureset.channel, np.arange(n_channels))
-    npt.assert_array_equal(list(featureset.amplitude.coords),
-                           ['name', 'channel', 'target'])
+    npt.assert_array_equal(sorted(featureset.amplitude.coords),
+                           ['channel', 'name', 'target'])
     npt.assert_array_equal(featureset.target.values, ['class1'])
 
 

--- a/mltsp/tests/test_predict.py
+++ b/mltsp/tests/test_predict.py
@@ -82,8 +82,8 @@ def test_single_predict_classification():
                                 "215153_metadata.dat"), custom_features_script=None)
         for fname, results in pred_results_dict.items():
             for el in results['pred_results']:
-                assert(el[0] in ['class1', 'class2', 'class3']
-                       or el in ['class1', 'class2', 'class3'])
+                assert(el[0] in [b'class1', b'class2', b'class3']
+                       or el in [b'class1', b'class2', b'class3'])
 
 
 @with_setup(copy_classification_test_data, remove_test_data)
@@ -103,8 +103,8 @@ def test_single_predict_classification_with_custom():
                                 cfg.CUSTOM_FEATURE_SCRIPT_FOLDER, "testfeature1.py"))
         for fname, results in pred_results_dict.items():
             for el in results['pred_results']:
-                assert(el[0] in ['class1', 'class2', 'class3']
-                       or el in ['class1', 'class2', 'class3'])
+                assert(el[0] in [b'class1', b'class2', b'class3']
+                       or el in [b'class1', b'class2', b'class3'])
 
 
 @with_setup(copy_classification_test_data, remove_test_data)
@@ -124,8 +124,8 @@ def test_multiple_predict_classification():
                                 custom_features_script=None)
         for fname, results in pred_results_dict.items():
             for el in results['pred_results']:
-                assert(el[0] in ['class1', 'class2', 'class3']
-                       or el in ['class1', 'class2', 'class3'])
+                assert(el[0] in [b'class1', b'class2', b'class3']
+                       or el in [b'class1', b'class2', b'class3'])
 
 
 @with_setup(copy_regression_test_data, remove_test_data)


### PR DESCRIPTION
This should fix all the remaining Python3 incompatibilities (which were almost all problems with the test code and how data read from files/web requests were being compared to known string values).

Fixes #75.