### PR TITLE
Add missing docs requirement, build docs on Drone

### DIFF
--- a/.drone/build.sh
+++ b/.drone/build.sh
@@ -42,3 +42,6 @@ mltsp --db-init
 
 echo "[Drone] Run test suite"
 make test_no_docker
+
+echo "[Drone] Build HTML documentation"
+make html

--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,7 @@ test_no_docker: test_backend_no_docker test_frontend_no_docker
 
 install:
 	pip install -r requirements.txt
+
+html:
+	pip install -q sphinx
+	export SPHINXOPTS=-W; make -C doc html

--- a/Makefile
+++ b/Makefile
@@ -57,5 +57,5 @@ install:
 	pip install -r requirements.txt
 
 html:
-	pip install -q sphinx
+	pip install -q sphinx -r requirements.readthedocs.txt
 	export SPHINXOPTS=-W; make -C doc html

--- a/dockerfiles/drone/Dockerfile
+++ b/dockerfiles/drone/Dockerfile
@@ -1,5 +1,6 @@
 FROM mltsp/base
 
+RUN apt-get update
 RUN apt-get install -y wget
 
 # Add RethinkDB repo
@@ -7,8 +8,7 @@ RUN \
   echo "deb http://download.rethinkdb.com/apt `lsb_release -cs` main" > /etc/apt/sources.list.d/rethinkdb.list && \
   wget -O- http://download.rethinkdb.com/apt/pubkey.gpg | apt-key add -
 
-RUN apt-get update
-RUN apt-get install -y wget curl git make \
+RUN apt-get install -y curl git make \
                        python-pip \
                        python-numpy python-scipy python-pandas python-flask \
                        python-parse python-psutil \
@@ -16,7 +16,15 @@ RUN apt-get install -y wget curl git make \
                        python-matplotlib python-nose python-yaml \
                        python-sklearn \
                        cython \
-                       rethinkdb docker.io phantomjs rabbitmq-server
+                       rethinkdb docker.io rabbitmq-server \
                        # Add python-docker when switching to utopic / vivid
+
+# Install PhantomJS
+RUN apt-get install -y fontconfig-config fonts-dejavu-core libfontconfig1 libfreetype6 \
+                       libjpeg-turbo8 libjpeg8 && \
+cd /usr/local/share && \
+wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2 && \
+tar xjf phantomjs-1.9.8-linux-x86_64.tar.bz2 && \
+ln -s /usr/local/share/phantomjs-1.9.8-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
 
 ENTRYPOINT ["/sbin/my_init", "--"]

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -1,0 +1,2 @@
+recommonmark
+numpydoc


### PR DESCRIPTION
Add missing `numpydoc` package to `requirements.readthedocs.txt`. Also add a Makefile target `make html` which compiles the docs (as in scikit-image), and have Drone test the docs build.

EDIT: Also fixes the broken front-end tests on Drone, once that Docker image is rebuilt.

EDIT EDIT: Fixes #37!