### PR TITLE
Mock out additional readthedocs libraries

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -318,11 +318,11 @@ class Mock(MagicMock):
     __version__ = MagicMock()
     random = MagicMock()
     stats = MagicMock()
-MOCK_MODULES = ['numpy', 'xray', 'sklearn', 'pandas', 'scipy', 'scipy.stats',
-                'scipy.linalg', 'scipy.special', 'sklearn.externals',
-                'sklearn.base', 'sklearn.ensemble', 'sklearn.linear_model',
-                'celery', 'dask', 'dask.async',
-                'mltsp.science_features._lomb_scargle']
+MOCK_MODULES = ['requests', 'parse', 'yaml', 'numpy', 'xray', 'sklearn',
+                'pandas', 'scipy', 'scipy.stats', 'scipy.linalg',
+                'scipy.special', 'sklearn.externals', 'sklearn.base',
+                'sklearn.ensemble', 'sklearn.linear_model', 'celery', 'dask',
+                'dask.async', 'mltsp.science_features._lomb_scargle']
 for m in MOCK_MODULES:
     sys.modules[m] = Mock()
 sys.path.append(os.path.join(os.path.dirname(__name__), '..'))

--- a/mltsp/science_features/amplitude.py
+++ b/mltsp/science_features/amplitude.py
@@ -38,10 +38,8 @@ def percent_difference_flux_percentile(x, base=10., exponent=-0.4):
 
 
 def flux_percentile_ratio(x, percentile_range, base=10., exponent=-0.4):
-    """
-    A ratio of ((50+x) flux percentile - (50-x) flux percentile) /
-                       (95 flux percentile - 5 flux percentile),
-    where x = percentile_range/2.
+    """A ratio of ((50+x) flux percentile - (50-x) flux percentile) /
+    (95 flux percentile - 5 flux percentile), where x = percentile_range/2.
 
     Assumes data is log-scaled; by default we assume inputs are scaled as
     x=10^(-0.4*y), corresponding to units of magnitudes. Computations are


### PR DESCRIPTION
Some libraries were already present on Drone (e.g. `requests`) and not readthedocs; from now on Drone should fail whenever readthedocs is missing a dependency or mock library.

Also fixes a docstring indentation warning.