### PR TITLE
Fix doc build by properly failing to import porterstemmer

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -317,15 +317,18 @@ try:
     import mock
 except:
     import unittest.mock as mock
+
 old_import = __import__
 def mock_import(name, *args, **kwargs):
     try:
         return old_import(name, *args, **kwargs)
     except Exception as e:
-        if 'mltsp' not in name:
-            return mock.MagicMock()
-        else:
+        if 'mltsp' in name:
             raise e
+        elif name == 'porterstemmer' or 'Stemmer' in name:
+            raise e
+        else:
+            return mock.MagicMock(name=name)
 __builtins__['__import__'] = mock_import
 
 


### PR DESCRIPTION
`__import__` trickery makes blocks like this not work correctly (from `sphinx.search.en`):

```
try:
    # http://bitbucket.org/methane/porterstemmer/
    from porterstemmer import Stemmer as CStemmer
    CSTEMMER = True
    PYSTEMMER = False
except ImportError:
    CSTEMMER = False
    try:
        from Stemmer import Stemmer as PyStemmer
        PYSTEMMER = True
    except ImportError:
        from sphinx.util.stemmer import PorterStemmer
        PYSTEMMER = False
```

I added a special case for this which seems to have fixed it; this is the price of trying to auto-mock dependencies, I guess...