### PR TITLE
Undo hacky porterstemmer/sphinx fix from #126

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -325,8 +325,6 @@ def mock_import(name, *args, **kwargs):
     except Exception as e:
         if 'mltsp' in name:
             raise e
-        elif name == 'porterstemmer' or 'Stemmer' in name:
-            raise e
         else:
             return mock.MagicMock(name=name)
 __builtins__['__import__'] = mock_import

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -1,3 +1,4 @@
+sphinx>=1.3.4
 mock
 recommonmark
 numpydoc


### PR DESCRIPTION
New version of sphinx (1.3.4) fixes the relevant bug (https://github.com/sphinx-doc/sphinx/issues/2183), so this undoes the patch from #126 and bumps the required sphinx version for readthedocs.