### PR TITLE
(re-)Undo hacky porterstemmer/sphinx fix from #126

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,5 +57,5 @@ install:
 	pip install -r requirements.txt
 
 html:
-	pip install -q sphinx -r requirements.readthedocs.txt
+	pip install -q -r requirements.readthedocs.txt
 	export SPHINXOPTS=-W; make -C doc html

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -132,7 +132,11 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+# Per https://github.com/snide/sphinx_rtd_theme: specify theme if not on RTD
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -324,11 +328,6 @@ def mock_import(name, *args, **kwargs):
         return old_import(name, *args, **kwargs)
     except (ImportError, KeyError) as ie:
         if 'mltsp' in name:  # Don't skip failure for a real API module
-            raise ie
-        # Sphinx has a bug that causes a crash if porterstemmer is imported,
-        # so we need this mock import to fail. May remove after release of
-        # https://github.com/sphinx-doc/sphinx/commit/f1518c5fc4446d63c0ba92150f5a226e3691aa62
-        elif name == 'porterstemmer' or 'Stemmer' in name:
             raise ie
         else:
             return mock.MagicMock(name=name)

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -1,2 +1,5 @@
+sphinx>=1.4a1
 recommonmark
 numpydoc
+PyStemmer
+sphinx-rtd-theme


### PR DESCRIPTION
Tried this in #129 but the relevant `sphinx` change didn't get actually released in that minor version update; this time it's there for real.