### PR TITLE
Replace git install of `stormpath` with new non-broken PyPI version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4
 flask
-git+git://github.com/stormpath/stormpath-sdk-python.git@2.1.6
+stormpath>=2.1.9
 git+git://github.com/stormpath/stormpath-flask.git@develop  # replace with Flask-Stormpath once they make a release with the Python 3 version
 docker-py
 numpy>=1.8.1


### PR DESCRIPTION
Old version wouldn't work on Linux under Python3 due to packaging problem, fixed in `stormpath==2.1.9`.